### PR TITLE
Switch build script to Node SEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 *.manifest.json
 *.manifest.auditfile
 mango.exe
+dist/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/Sainan/steam-manifest-tools.git"
   },
   "scripts": {
-    "build": "bun build mango.js --compile"
+    "build": "node ./scripts/build.mjs"
   },
   "dependencies": {
     "@doctormckay/steam-crypto": "^1.2.0",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { chmodSync, copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const distDir = join(projectRoot, 'dist');
+const seaConfigPath = join(projectRoot, 'sea-config.json');
+const blobPath = join(distDir, 'mango.blob');
+const outputBinary = join(distDir, 'mango');
+
+mkdirSync(distDir, { recursive: true });
+
+execSync(`node --experimental-sea-config ${JSON.stringify(seaConfigPath)}`, {
+  stdio: 'inherit'
+});
+
+copyFileSync(process.execPath, outputBinary);
+
+try {
+  execSync(
+    `npx --yes postject ${JSON.stringify(outputBinary)} NODE_SEA_BLOB ${JSON.stringify(blobPath)} --sentinel-fuse`,
+    { stdio: 'inherit' }
+  );
+} catch (error) {
+  throw new Error(
+    'Failed to embed the SEA blob using postject. Ensure you have access to the npm registry or install postject manually.',
+    { cause: error }
+  );
+}
+
+chmodSync(outputBinary, 0o755);
+
+console.log(`Created single executable at ${outputBinary}`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -26,7 +26,7 @@ try {
     'NODE_SEA_BLOB',
     JSON.stringify(blobPath),
     '--sentinel-fuse',
-    'NODE_SEA_FUSE_R30'
+    'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 '
   ].join(' ');
 
   execSync(postjectCommand, { stdio: 'inherit' });

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -20,10 +20,16 @@ execSync(`node --experimental-sea-config ${JSON.stringify(seaConfigPath)}`, {
 copyFileSync(process.execPath, outputBinary);
 
 try {
-  execSync(
-    `npx --yes postject ${JSON.stringify(outputBinary)} NODE_SEA_BLOB ${JSON.stringify(blobPath)} --sentinel-fuse`,
-    { stdio: 'inherit' }
-  );
+  const postjectCommand = [
+    'npx --yes postject',
+    JSON.stringify(outputBinary),
+    'NODE_SEA_BLOB',
+    JSON.stringify(blobPath),
+    '--sentinel-fuse',
+    'NODE_SEA_FUSE_R30'
+  ].join(' ');
+
+  execSync(postjectCommand, { stdio: 'inherit' });
 } catch (error) {
   throw new Error(
     'Failed to embed the SEA blob using postject. Ensure you have access to the npm registry or install postject manually.',

--- a/sea-config.json
+++ b/sea-config.json
@@ -1,0 +1,5 @@
+{
+  "main": "./mango.js",
+  "output": "./dist/mango.blob",
+  "disableExperimentalSEAWarning": true
+}


### PR DESCRIPTION
## Summary
- replace the Bun-based build command with a Node single executable application workflow
- add a SEA configuration file and helper script to drive the build
- ignore the generated dist artifacts in version control

## Testing
- npm run build *(fails: registry.npmjs.org/postject returned 403 in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0874b7008325a5abec8bcfa0f8c1)